### PR TITLE
FEATURE: Work limited number of jobs

### DIFF
--- a/Classes/TYPO3/Jobqueue/Common/Command/JobCommandController.php
+++ b/Classes/TYPO3/Jobqueue/Common/Command/JobCommandController.php
@@ -38,12 +38,16 @@ class JobCommandController extends CommandController
      * Work on a queue and execute jobs
      *
      * @param string $queueName The name of the queue
+     * @param integer $limit The max number of jobs that should execute before exiting.
      * @return void
      */
-    public function workCommand($queueName)
+    public function workCommand($queueName, $limit = 0)
     {
+        $runInfiniteJobs = ($limit === 0 || $limit < 0);
+        $jobsDone = 0;
         do {
             try {
+                $jobsDone++;
                 $this->jobManager->waitAndExecute($queueName);
             } catch (JobQueueException $exception) {
                 $this->outputLine($exception->getMessage());
@@ -53,7 +57,7 @@ class JobCommandController extends CommandController
             } catch (\Exception $exception) {
                 $this->outputLine('Unexpected exception during job execution: %s', array($exception->getMessage()));
             }
-        } while (true);
+        } while ($runInfiniteJobs || $jobsDone < $limit);
     }
 
     /**


### PR DESCRIPTION
Long running jobs can exhaust the PHP memory limit. This allows you to
run as few or as many jobs as you'd like.

To use:

  ./flow job:work --limit <number> <queue-name>

With Zsh, you could do something like this to do the next 500 jobs:

  repeat 100 do ./flow job:work --limit=5 org.typo3.docs.combo; echo "did 5 jobs"; done