### PR TITLE
FEATURE: allow to define a global Queue Name Prefix

### DIFF
--- a/Classes/Queue/QueueManager.php
+++ b/Classes/Queue/QueueManager.php
@@ -71,7 +71,15 @@ class QueueManager
         }
 
         $options = isset($this->settings['queues'][$queueName]['options']) ? $this->settings['queues'][$queueName]['options'] : array();
-        $queue = new $queueObjectName($queueName, $options);
+
+
+        if (isset($this->settings['queueNamePrefix'])) {
+            $queueNameWithPrefix = $this->settings['queueNamePrefix'] . $queueName;
+        } else {
+            $queueNameWithPrefix = $queueName;
+        }
+
+        $queue = new $queueObjectName($queueNameWithPrefix, $options);
 
         $this->queues[$queueName] = $queue;
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,6 +1,9 @@
 Flowpack:
   JobQueue:
     Common:
+      # if defined, all queues are prefixed with the configured "queueNamePrefix". This helps if multiple
+      # Flow instances share the same queue service.
+      queueNamePrefix: ''
       queues: []
 #        example:
 #          className: 'Flownative\JobQueue\Sqlite\Queue\SqliteQueue'

--- a/Tests/Unit/Queue/QueueManagerTest.php
+++ b/Tests/Unit/Queue/QueueManagerTest.php
@@ -36,6 +36,7 @@ class QueueManagerTest extends UnitTestCase
 
         $queue = $queueManager->getQueue('TestQueue');
         $this->assertInstanceOf('Flowpack\JobQueue\Common\Tests\Unit\Fixtures\TestQueue', $queue);
+        $this->assertSame('TestQueue', $queue->getName());
     }
 
     /**
@@ -76,5 +77,24 @@ class QueueManagerTest extends UnitTestCase
 
         $queue = $queueManager->getQueue('TestQueue');
         $this->assertSame($queue, $queueManager->getQueue('TestQueue'));
+    }
+
+    /**
+     * @test
+     */
+    public function queuePrefixIsProperlyUsed()
+    {
+        $queueManager = new QueueManager();
+        $queueManager->injectSettings(array(
+            'queueNamePrefix' => 'specialQueue',
+            'queues' => array(
+                'TestQueue' => array(
+                    'className' => 'Flowpack\JobQueue\Common\Tests\Unit\Fixtures\TestQueue'
+                )
+            )
+        ));
+
+        $queue = $queueManager->getQueue('TestQueue');
+        $this->assertSame('specialQueueTestQueue', $queue->getName());
     }
 }


### PR DESCRIPTION
This especially helps if multiple Flow instances share the same queue service.