### PR TITLE
!!! FEATURE: Allow defer annotation to specify custom options

### DIFF
--- a/Classes/Annotations/Defer.php
+++ b/Classes/Annotations/Defer.php
@@ -26,6 +26,12 @@ final class Defer
     public $queueName;
 
     /**
+     * Optional key/value array of options passed to the queue (for example array('delay' => 123) - Supported options depend on the concrete queue implementation)
+     * @var array
+     */
+    public $options;
+
+    /**
      * @param array $values
      * @throws \InvalidArgumentException
      */
@@ -35,5 +41,6 @@ final class Defer
             throw new \InvalidArgumentException('A Defer annotation must specify a queueName.', 1334128835);
         }
         $this->queueName = isset($values['queueName']) ? $values['queueName'] : $values['value'];
+        $this->options = isset($values['options']) ? $values['options'] : [];
     }
 }

--- a/Classes/Job/Aspect/DeferMethodCallAspect.php
+++ b/Classes/Job/Aspect/DeferMethodCallAspect.php
@@ -53,10 +53,10 @@ class DeferMethodCallAspect
         if ($this->processingJob) {
             return $joinPoint->getAdviceChain()->proceed($joinPoint);
         }
+        /** @var Defer $deferAnnotation */
         $deferAnnotation = $this->reflectionService->getMethodAnnotation($joinPoint->getClassName(), $joinPoint->getMethodName(), Defer::class);
-        $queueName = $deferAnnotation->queueName;
         $job = new StaticMethodCallJob($joinPoint->getClassName(), $joinPoint->getMethodName(), $joinPoint->getMethodArguments());
-        $this->jobManager->queue($queueName, $job);
+        $this->jobManager->queue($deferAnnotation->queueName, $job, $deferAnnotation->options);
         return null;
     }
 

--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -19,6 +19,8 @@ use Flowpack\JobQueue\Common\Queue\QueueManager;
 
 /**
  * Job manager
+ *
+ * @Flow\Scope("singleton")
  */
 class JobManager
 {
@@ -38,17 +40,18 @@ class JobManager
      * Put a job in the queue
      *
      * @param string $queueName
-     * @param JobInterface $job
+     * @param JobInterface $job The job to submit to the queue
+     * @param array $options Simple key/value array with options that will be passed to the queue for this job (optional)
      * @return void
      */
-    public function queue($queueName, JobInterface $job)
+    public function queue($queueName, JobInterface $job, array $options = [])
     {
         $queue = $this->queueManager->getQueue($queueName);
 
         $payload = serialize($job);
         $message = new Message($payload);
 
-        $queue->submit($message);
+        $queue->submit($message, $options);
     }
 
     /**

--- a/Classes/Queue/QueueInterface.php
+++ b/Classes/Queue/QueueInterface.php
@@ -26,9 +26,10 @@ interface QueueInterface
      * another message with the same identifier already exists.
      *
      * @param Message $message
+     * @param array $options Simple key/value array with options, supported options depend on the queue implementation
      * @return string The identifier of the message under which it was queued
      */
-    public function submit(Message $message);
+    public function submit(Message $message, array $options = []);
 
     /**
      * Wait for a message in the queue and remove the message from the queue for processing

--- a/Tests/Unit/Fixtures/TestQueue.php
+++ b/Tests/Unit/Fixtures/TestQueue.php
@@ -42,6 +42,11 @@ class TestQueue implements QueueInterface
     protected $options;
 
     /**
+     * @var array
+     */
+    protected $lastSubmitOptions;
+
+    /**
      *
      * @param string $name
      * @param array $options
@@ -72,12 +77,22 @@ class TestQueue implements QueueInterface
 
     /**
      * @param Message $message
+     * @param array $options
      * @return void
      */
-    public function submit(Message $message)
+    public function submit(Message $message, array $options = [])
     {
         // TODO Unique identifiers
         $this->messages[] = $message;
+        $this->lastSubmitOptions = $options;
+    }
+
+    /**
+     * @return array
+     */
+    public function getLastSubmitOptions()
+    {
+        return $this->lastSubmitOptions;
     }
 
     /**

--- a/Tests/Unit/Job/JobManagerTest.php
+++ b/Tests/Unit/Job/JobManagerTest.php
@@ -11,7 +11,8 @@ namespace Flowpack\JobQueue\Common\Tests\Unit\Job;
  * source code.
  */
 
-use TYPO3\Flow\Reflection\ObjectAccess;
+use Flowpack\JobQueue\Common\Queue\Message;
+use Flowpack\JobQueue\Common\Tests\Unit\Fixtures\TestQueue;
 use TYPO3\Flow\Tests\UnitTestCase;
 use Flowpack\JobQueue\Common\Job\JobManager;
 use Flowpack\JobQueue\Common\Queue\QueueManager;
@@ -23,44 +24,53 @@ use Flowpack\JobQueue\Common\Tests\Unit\Fixtures\TestJob;
 class JobManagerTest extends UnitTestCase
 {
     /**
-     * @var QueueManager
-     */
-    protected $queueManager;
-
-    /**
      * @var JobManager
      */
     protected $jobManager;
 
     /**
-     *
+     * @var QueueManager|\PHPUnit_Framework_MockObject_MockObject
      */
+    protected $mockQueueManager;
+
+    /**
+     * @var TestQueue
+     */
+    protected $testQueue;
+
+
     public function setUp()
     {
-        $this->queueManager = new QueueManager();
-        $this->queueManager->injectSettings(array(
-            'queues' => array(
-                'TestQueue' => array(
-                    'className' => 'Flowpack\JobQueue\Common\Tests\Unit\Fixtures\TestQueue'
-                )
-            )
-        ));
+        $this->mockQueueManager = $this->getMockBuilder(QueueManager::class)->disableOriginalConstructor()->getMock();
+        $this->testQueue = new TestQueue('TestQueue', array());
+        $this->mockQueueManager->expects($this->any())->method('getQueue')->with('TestQueue')->will($this->returnValue($this->testQueue));
 
         $this->jobManager = new JobManager();
-        ObjectAccess::setProperty($this->jobManager, 'queueManager', $this->queueManager, true);
+        $this->inject($this->jobManager, 'queueManager', $this->mockQueueManager);
     }
 
     /**
      * @test
      */
-    public function queuePublishesMessageToQueue()
+    public function queueSubmitsMessageToQueue()
     {
         $job = new TestJob();
         $this->jobManager->queue('TestQueue', $job);
 
-        $testQueue = $this->queueManager->getQueue('TestQueue');
-        $message = $testQueue->peek();
-        $this->assertInstanceOf('Flowpack\JobQueue\Common\Queue\Message', $message);
+        $message = $this->testQueue->peek();
+        $this->assertInstanceOf(Message::class, $message);
+    }
+
+    /**
+     * @test
+     */
+    public function queuePassesOptionsToQueue()
+    {
+        $mockOptions = array('foo' => 'Bar', 'baz' => 'Foos');
+        $job = new TestJob();
+        $this->jobManager->queue('TestQueue', $job, $mockOptions);
+
+        $this->assertSame($mockOptions, $this->testQueue->getLastSubmitOptions());
     }
 
     /**


### PR DESCRIPTION
	  …
This change adds an optional `option` argument to the `Defer`
annotation that allows for specifying arbitrary parameters that are
passed to the Queue when a job is queued::

  @Job\Defer(queueName="some-queue", options="{delay: 123}")
  public function deferredMethod() { //...

Note: The supported options depend on the specific queue
implementation. The `Flowpack.JobQueue.Beanstalkd` queue for example
supports the options "delay", "priority" and "ttr".

This is a breaking change because it changes the signature of
`QueueInterface::submit()` and `JobManager::queue()`.