### PR TITLE
BUGFIX: Unset job processing flag after execution

### DIFF
--- a/Classes/Job/StaticMethodCallJob.php
+++ b/Classes/Job/StaticMethodCallJob.php
@@ -81,8 +81,9 @@ class StaticMethodCallJob implements JobInterface
             call_user_func_array([$service, $methodName], $this->arguments);
             return true;
         } catch (\Exception $exception) {
-            $this->deferMethodCallAspect->setProcessingJob(false);
             throw $exception;
+        } finally {
+            $this->deferMethodCallAspect->setProcessingJob(false);
         }
     }
 


### PR DESCRIPTION
Fixes static method call job to reset the `processingJob` flag which prevents further queuing of deferred methods in any case.