### PR TITLE
Add gettype calls to make isSimpleType happy

### DIFF
--- a/Classes/Job/StaticMethodCallJob.php
+++ b/Classes/Job/StaticMethodCallJob.php
@@ -95,9 +95,13 @@ class StaticMethodCallJob implements JobInterface
         $arguments = [];
         foreach($this->arguments as $argumentValue) {
             if (TypeHandling::isSimpleType(gettype($argumentValue))) {
-                $arguments[] = gettype($argumentValue);
+                if (is_array($argumentValue)) {
+                    $arguments[] = gettype($argumentValue);
+                } else {
+                    $arguments[] = $argumentValue;
+                }
             } else {
-                $arguments[] = '[' . gettype($argumentValue) . ']';
+                $arguments[] = '[' . TypeHandling::getTypeForValue($argumentValue) . ']';
             }
         }
         return sprintf('%s::%s(%s)', $this->className, $this->methodName, implode(', ', $arguments));

--- a/Classes/Job/StaticMethodCallJob.php
+++ b/Classes/Job/StaticMethodCallJob.php
@@ -94,8 +94,8 @@ class StaticMethodCallJob implements JobInterface
     {
         $arguments = [];
         foreach($this->arguments as $argumentValue) {
-            if (TypeHandling::isSimpleType($argumentValue)) {
-                $arguments[] = $argumentValue;
+            if (TypeHandling::isSimpleType(gettype($argumentValue))) {
+                $arguments[] = gettype($argumentValue);
             } else {
                 $arguments[] = '[' . gettype($argumentValue) . ']';
             }


### PR DESCRIPTION
When creating the label the `isSimpleType` call was filled with array arguments and crashed because of the `string` typehint. Not getting the type for the arguments array can result in "array to string conversion notice" as `isSimpleType` returns true for an array