### PR TITLE
FEATURE: Hand message over via cache

### DIFF
--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,0 +1,3 @@
+FlowPackJobQueueCommon_MessageCache:
+  frontend: Neos\Cache\Frontend\VariableFrontend
+  persistent: true

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,19 @@
+Flowpack\JobQueue\Common\Job\JobManager:
+  properties:
+    messageCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: FlowPackJobQueueCommon_MessageCache
+
+Flowpack\JobQueue\Common\Command\JobCommandController:
+  properties:
+    messageCache:
+      object:
+        factoryObjectName: Neos\Flow\Cache\CacheManager
+        factoryMethodName: getCache
+        arguments:
+          1:
+            value: FlowPackJobQueueCommon_MessageCache


### PR DESCRIPTION
If you hand over some data (eg elasticsearch queue indexer with 500 nodes per job) to an isolated command run you exceed the escapeshellarg max input length. To avoid this, this change passes the payload via a separate cache. 

Fixes: #25 