### PR TITLE
BUGFIX: Remove message cache file on failure

### DIFF
--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -120,7 +120,7 @@ class JobManager
                 throw new JobQueueException(sprintf('Job execution for job (message: "%s", queue: "%s") failed (%d/%d trials) - ABORTING', $message->getIdentifier(), $queue->getName(), $message->getNumberOfReleases() + 1, $maximumNumberOfReleases + 1), 1334056584, $exception);
             }
         } finally {
-            if($messageCacheIdentifier !== null) {
+            if ($messageCacheIdentifier !== null) {
                 $this->messageCache->remove($messageCacheIdentifier);
             }
         }


### PR DESCRIPTION
When a job execution failed, the message was not removed from the
cache. This change fixes that by removing the cache entry in a `finally`
block.