### PR TITLE
BUGFIX: maximumNumberOfReleases default value

### DIFF
--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -108,7 +108,7 @@ class JobManager
                 $this->executeJobForMessage($queue, $message);
             }
         } catch (\Exception $exception) {
-            $maximumNumberOfReleases = isset($queueSettings['maximumNumberOfReleases']) ? (integer)$queueSettings['maximumNumberOfReleases'] : 0;
+            $maximumNumberOfReleases = isset($queueSettings['maximumNumberOfReleases']) ? (integer)$queueSettings['maximumNumberOfReleases'] : 3;
             if ($message->getNumberOfReleases() < $maximumNumberOfReleases) {
                 $releaseOptions = isset($queueSettings['releaseOptions']) ? $queueSettings['releaseOptions'] : [];
                 $queue->release($message->getIdentifier(), $releaseOptions);

--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -28,6 +28,11 @@ use Flowpack\JobQueue\Common\Queue\QueueManager;
 class JobManager
 {
     /**
+     * @var int
+     */
+    const DEFAULT_MAXIMUM_NUMBER_RELEASES = 3;
+
+    /**
      * @Flow\Inject
      * @var QueueManager
      */
@@ -108,7 +113,9 @@ class JobManager
                 $this->executeJobForMessage($queue, $message);
             }
         } catch (\Exception $exception) {
-            $maximumNumberOfReleases = isset($queueSettings['maximumNumberOfReleases']) ? (integer)$queueSettings['maximumNumberOfReleases'] : 3;
+            $maximumNumberOfReleases = isset($queueSettings['maximumNumberOfReleases']) ?
+                (int)$queueSettings['maximumNumberOfReleases'] :
+                self::DEFAULT_MAXIMUM_NUMBER_RELEASES;
             if ($message->getNumberOfReleases() < $maximumNumberOfReleases) {
                 $releaseOptions = isset($queueSettings['releaseOptions']) ? $queueSettings['releaseOptions'] : [];
                 $queue->release($message->getIdentifier(), $releaseOptions);


### PR DESCRIPTION
According to the doc the default value is 3. Obviously we also could adjust the documentation, but a default value larger than 0 makes sense to me.