### PR TITLE
[FEATURE] Persist unpersisted changes in CLI after messageFinished signal

### DIFF
--- a/Classes/Package.php
+++ b/Classes/Package.php
@@ -1,0 +1,33 @@
+<?php
+namespace Flowpack\JobQueue\Common;
+
+use Flowpack\JobQueue\Common\Job\JobManager;
+use Flowpack\JobQueue\Common\Queue\Message;
+use Flowpack\JobQueue\Common\Queue\QueueInterface;
+use Neos\Flow\Core\Bootstrap;
+use Neos\Flow\Package\Package as BasePackage;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
+
+class Package extends BasePackage
+{
+
+    /**
+     * @param Bootstrap $bootstrap The current bootstrap
+     * @return void
+     */
+    public function boot(Bootstrap $bootstrap)
+    {
+        if (PHP_SAPI === 'cli') {
+            $dispatcher = $bootstrap->getSignalSlotDispatcher();
+
+            $dispatcher->connect(JobManager::class, 'messageFinished', function (QueueInterface $queue, Message $message) use ($bootstrap) {
+                /** @var PersistenceManagerInterface $persistenceManager */
+                $persistenceManager = $bootstrap->getObjectManager()->get(PersistenceManagerInterface::class);
+
+                if ($persistenceManager->hasUnpersistedChanges()) {
+                    $persistenceManager->persistAll();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Once a `messageFinished` signal is emitted, the Persistence Manager persist all unpersisted changes. This is to have the jobmanager act as a normal CLI command, known from the a CommandController command

Resolves #44 