### PR TITLE
Output verbose exception msg on separate line

### DIFF
--- a/Classes/Command/JobCommandController.php
+++ b/Classes/Command/JobCommandController.php
@@ -88,7 +88,8 @@ class JobCommandController extends CommandController
                 $numberOfJobExecutions ++;
                 $this->outputLine('<error>%s</error>', [$exception->getMessage()]);
                 if ($verbose && $exception->getPrevious() instanceof \Exception) {
-                    $this->outputLine('  Reason: %s', [$exception->getPrevious()->getMessage()]);
+                    $this->outputLine('Reason:');
+                    $this->outputLine($exception->getPrevious()->getMessage());
                 }
             } catch (\Exception $exception) {
                 $this->outputLine('<error>Unexpected exception during job execution: %s, aborting...</error>', [$exception->getMessage()]);


### PR DESCRIPTION
This change outputs the exception message on a worker in verbose mode on a seperate line. This allows parsing json data on console output.