### PR TITLE
TASK: Extend the advice for naming queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Flowpack:
 
 With this a queue named `test` will be available.
 
-*Note:* For reusable packages you should consider adding a vendor specific prefixes to avoid collisions
+*Note:* For reusable packages you should consider adding a vendor specific prefixes to avoid collisions. We recommend to use a classname or the package name with the function name (e.g. Flowpack.ElasticSearch.ContentRepositoryQueueIndexer. 
 
 ### Queue parameters
 


### PR DESCRIPTION
The naming of the queues follows the same convention as for EEL helpers and the like. So maybe we should take a closer look at this.