### PR TITLE
FEATURE: Allow jobManager to be interrupted by system SIGINT

### DIFF
--- a/Classes/InterruptException.php
+++ b/Classes/InterruptException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Flowpack\JobQueue\Common;
+
+class InterruptException extends Exception
+{
+
+}

--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -11,6 +11,7 @@ namespace Flowpack\JobQueue\Common\Job;
  * source code.
  */
 
+use Flowpack\JobQueue\Common\InterruptException;
 use Flowpack\JobQueue\Common\Queue\QueueInterface;
 use Neos\Cache\Frontend\VariableFrontend;
 use Neos\Flow\Annotations as Flow;
@@ -173,6 +174,18 @@ class JobManager
             $job = unserialize($message->getPayload());
             return $job;
         }, $messages);
+    }
+
+    /**
+     * This method is here to be called by queues if they reached local polling timeouts, if this applies
+     *
+     * @throws InterruptException
+     */
+    public function interruptMe(): void
+    {
+        if (function_exists('pcntl_signal_dispatch')) {
+            pcntl_signal_dispatch();
+        }
     }
 
     /**


### PR DESCRIPTION
This is a first draft, to checkout if this is something you are even going to accept. (It is fully functionally though - but it needs to be documented - which I'd love to do, if you accept)

This change allows the JobWorker to be interrupted on the Command-Line by pressing CTRL+C at a safe state (it will only be interrupted if the last job had been completed successfully or a timeout occured)

Additionally the JobManager provides a new Message queues might use to signal, they are now safe to interrupt (ideally before they go sleeping in their own "waiting for timeout" handling)