### PR TITLE
BUGFIX: fix functional test cases for AbstractQueueTest with Flow 7

### DIFF
--- a/Tests/Functional/AbstractQueueTest.php
+++ b/Tests/Functional/AbstractQueueTest.php
@@ -65,7 +65,7 @@ abstract class AbstractQueueTest extends FunctionalTestCase
     public function submitReturnsMessageId()
     {
         $messageId = $this->queue->submit('some message payload');
-        self::assertInternalType('string', $messageId);
+        self::assertEquals('string', gettype($messageId), 'messageId should be type of string');
     }
 
     /**


### PR DESCRIPTION
With Flow 7, Functional Tests throw an error because `assertInternalType` has been removed in PHPUnit 9.0. 

To ensure compatibility with Flow 5 and PHPUnit 7.1, the bugfix uses `assertEqual` instead of `assertIsString`.