### PR TITLE
"defer" annotation as PHP 8 attribute

### DIFF
--- a/Classes/Annotations/Defer.php
+++ b/Classes/Annotations/Defer.php
@@ -11,12 +11,14 @@ namespace Flowpack\JobQueue\Common\Annotations;
  * source code.
  */
 
-use Doctrine\Common\Annotations\Annotation as DoctrineAnnotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
- * @DoctrineAnnotation\Target("METHOD")
+ * @NamedArgumentConstructor
+ * @Target("METHOD")
  */
+#[\Attribute(\Attribute::TARGET_METHOD)]
 final class Defer
 {
     /**
@@ -32,15 +34,16 @@ final class Defer
     public $options;
 
     /**
-     * @param array $values
-     * @throws \InvalidArgumentException
+     * @param string|null $queueName
+     * @param array|null $options
+     * @param string|null $value
      */
-    public function __construct(array $values)
+    public function __construct(?string $queueName = null, ?array $options = null, ?string $value = null)
     {
-        if (!isset($values['value']) && !isset($values['queueName'])) {
-            throw new \InvalidArgumentException('A Defer annotation must specify a queueName.', 1334128835);
+        if ($value === null && $queueName === null) {
+            throw new \InvalidArgumentException('A Defer attribute must specify a queueName.', 1334128835);
         }
-        $this->queueName = isset($values['queueName']) ? $values['queueName'] : $values['value'];
-        $this->options = isset($values['options']) ? $values['options'] : [];
+        $this->queueName = $queueName ?? $value;
+        $this->options = $options ?? [];
     }
 }

--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ Neos Flow package that allows for asynchronous and distributed execution of task
   }
   ```
 
+  or use attributes instead of annotations (PHP 8.0 and later):
+  
+  ```php
+  use Flowpack\JobQueue\Common\Annotations as Job;
+  
+  class SomeClass {
+  
+      #[Job\Defer(queueName: "some-queue")]
+      public function sendEmail($emailAddress)
+      {
+          // send some email to $emailAddress
+      }
+  }
+  ```
+  
   *Note:* The method needs to be *public* and it must not return anything
 
 5. **Start the worker (if required)**


### PR DESCRIPTION
This changes the implementation of the @Defer annotation so that it
can also be used as a PHP 8 attribute. The annotation is backwards
compatible and can still be used in the previous way as part of a
doc comment.

Example:

```php
    #[Defer(queueName: "MyJobQueue")]
    public function handle(SomeCommand $command): void
    {
       ...
    }
```