### PR TITLE
BUGFIX: Adjust signature of JobManager signals to support Throwables

### DIFF
--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -253,12 +253,12 @@ class JobManager
      * @param QueueInterface $queue The queue the released message belongs to
      * @param Message $message The message that was released to the queue again
      * @param array $releaseOptions The options that were passed to the release call
-     * @param \Exception $jobExecutionException The exception (if any) thrown by the job execution
+     * @param \Throwable|null $jobExecutionThrowable The exception or error (if any) thrown by the job execution
      * @return void
      * @Flow\Signal
      * @api
      */
-    protected function emitMessageReleased(QueueInterface $queue, Message $message, array $releaseOptions, \Exception $jobExecutionException = null): void
+    protected function emitMessageReleased(QueueInterface $queue, Message $message, array $releaseOptions, \Throwable $jobExecutionThrowable = null): void
     {
     }
 
@@ -267,12 +267,12 @@ class JobManager
      *
      * @param QueueInterface $queue The queue the failed message belongs to
      * @param Message $message The message that could not be executed successfully
-     * @param \Exception $jobExecutionException The exception (if any) thrown by the job execution
+     * @param \Throwable|null $jobExecutionThrowable The exception or error (if any) thrown by the job execution
      * @return void
      * @Flow\Signal
      * @api
      */
-    protected function emitMessageFailed(QueueInterface $queue, Message $message, \Exception $jobExecutionException = null): void
+    protected function emitMessageFailed(QueueInterface $queue, Message $message, \Throwable $jobExecutionThrowable = null): void
     {
     }
 

--- a/Classes/Job/JobManager.php
+++ b/Classes/Job/JobManager.php
@@ -134,13 +134,13 @@ class JobManager
             if ($message->getNumberOfReleases() < $maximumNumberOfReleases) {
                 $releaseOptions = isset($queueSettings['releaseOptions']) ? $queueSettings['releaseOptions'] : [];
                 $queue->release($message->getIdentifier(), $releaseOptions);
-                $this->emitMessageReleased($queue, $message, $releaseOptions, $throwable);
+                $this->emitMessageReleased($queue, $message, $releaseOptions, new \RuntimeException($throwable->getMessage(), 1659019014, $throwable));
                 $logMessage = $this->throwableStorage->logThrowable($throwable);
                 $this->logger->error($logMessage, LogEnvironment::fromMethodName(__METHOD__));
                 throw new JobQueueException(sprintf('Job execution for job (message: "%s", queue: "%s") failed (%d/%d trials) - RELEASE', $message->getIdentifier(), $queue->getName(), $message->getNumberOfReleases() + 1, $maximumNumberOfReleases + 1), 1334056583, $throwable);
             } else {
                 $queue->abort($message->getIdentifier());
-                $this->emitMessageFailed($queue, $message, $throwable);
+                $this->emitMessageFailed($queue, $message, new \RuntimeException($throwable->getMessage(), 1659019015, $throwable));
                 $logMessage = $this->throwableStorage->logThrowable($throwable);
                 $this->logger->error($logMessage, LogEnvironment::fromMethodName(__METHOD__));
                 throw new JobQueueException(sprintf('Job execution for job (message: "%s", queue: "%s") failed (%d/%d trials) - ABORTING', $message->getIdentifier(), $queue->getName(), $message->getNumberOfReleases() + 1, $maximumNumberOfReleases + 1), 1334056584, $throwable);
@@ -253,12 +253,12 @@ class JobManager
      * @param QueueInterface $queue The queue the released message belongs to
      * @param Message $message The message that was released to the queue again
      * @param array $releaseOptions The options that were passed to the release call
-     * @param \Throwable|null $jobExecutionThrowable The exception or error (if any) thrown by the job execution
+     * @param \Exception|null $jobExecutionException The exception (if any) thrown by the job execution
      * @return void
      * @Flow\Signal
      * @api
      */
-    protected function emitMessageReleased(QueueInterface $queue, Message $message, array $releaseOptions, \Throwable $jobExecutionThrowable = null): void
+    protected function emitMessageReleased(QueueInterface $queue, Message $message, array $releaseOptions, \Exception $jobExecutionException = null): void
     {
     }
 
@@ -267,12 +267,12 @@ class JobManager
      *
      * @param QueueInterface $queue The queue the failed message belongs to
      * @param Message $message The message that could not be executed successfully
-     * @param \Throwable|null $jobExecutionThrowable The exception or error (if any) thrown by the job execution
+     * @param \Exception|null $jobExecutionException The exception (if any) thrown by the job execution
      * @return void
      * @Flow\Signal
      * @api
      */
-    protected function emitMessageFailed(QueueInterface $queue, Message $message, \Throwable $jobExecutionThrowable = null): void
+    protected function emitMessageFailed(QueueInterface $queue, Message $message, \Exception $jobExecutionException = null): void
     {
     }
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ class Package extends BasePackage
 
         $dispatcher->connect(
             JobManager::class, 'messageFailed',
-            function(QueueInterface $queue, Message $message, \Exception $jobExecutionException = null) use ($bootstrap) {
+            function(QueueInterface $queue, Message $message, \Throwable $jobExecutionException = null) use ($bootstrap) {
                 $additionalData = [
                     'queue' => $queue->getName(),
                     'message' => $message->getIdentifier()

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ class Package extends BasePackage
 
         $dispatcher->connect(
             JobManager::class, 'messageFailed',
-            function(QueueInterface $queue, Message $message, \Throwable $jobExecutionException = null) use ($bootstrap) {
+            function(QueueInterface $queue, Message $message, \Exception $jobExecutionException = null) use ($bootstrap) {
                 $additionalData = [
                     'queue' => $queue->getName(),
                     'message' => $message->getIdentifier()


### PR DESCRIPTION
This is a follow-up for #59 that adjusts the signatures of
`JobManager::emitMessageReleased()` and `JobManager::emitMessageFailed()`
to avoid type errors when invoking the methods.

Related: #59